### PR TITLE
Don't escape characters in a term query

### DIFF
--- a/lib/blacklight/access_controls/enforcement.rb
+++ b/lib/blacklight/access_controls/enforcement.rb
@@ -70,7 +70,7 @@ module Blacklight
         # for groups
         permission_types.map do |type|
           field = solr_field_for(type, 'group')
-          groups = ability.user_groups.map { |g| escape_value(g) }
+          groups = ability.user_groups
           # The parens are required to properly OR the cases together.
           "({!terms f=#{field}}#{groups.join(',')})"
         end

--- a/spec/unit/enforcement_spec.rb
+++ b/spec/unit/enforcement_spec.rb
@@ -47,8 +47,8 @@ describe Blacklight::AccessControls::Enforcement do
       end
 
       it "searches for my groups" do
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,faculty,africana\\-faculty,registered})
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,faculty,africana\\-faculty,registered})
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,faculty,africana-faculty,registered})
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,faculty,africana-faculty,registered})
       end
 
       it "searches for my user key" do
@@ -106,27 +106,27 @@ describe Blacklight::AccessControls::Enforcement do
     context 'slashes in the group names' do
       let(:groups) { ["abc/123","cde/567"] }
 
-      it "should escape slashes" do
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,abc\\/123,cde\\/567,registered})
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,abc\\/123,cde\\/567,registered})
+      it "doesn't escape slashes" do
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,abc/123,cde/567,registered})
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,abc/123,cde/567,registered})
       end
     end
 
     context 'spaces in the group names' do
       let(:groups) { ["abc 123","cd/e 567"] }
 
-      it "escapes spaces in group names" do
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,abc\\ 123,cd\\/e\\ 567,registered})
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,abc\\ 123,cd\\/e\\ 567,registered})
+      it "doesn't escape spaces in group names" do
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,abc 123,cd/e 567,registered})
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,abc 123,cd/e 567,registered})
       end
     end
 
     context 'colons in the groups names' do
       let(:groups) { ["abc:123","cde:567"] }
 
-      it "should escape colons" do
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,abc\\:123,cde\\:567,registered})
-        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,abc\\:123,cde\\:567,registered})
+      it "doesn't escape colons" do
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=discover_access_group_ssim\}public,abc:123,cde:567,registered})
+        expect(@solr_parameters[:fq].first).to match(%r{\{!terms f=read_access_group_ssim\}public,abc:123,cde:567,registered})
       end
     end
   end


### PR DESCRIPTION
As far as I can tell, escaping keeps it from working properly