### PR TITLE
Remove Rails deprecation warning on before_filter

### DIFF
--- a/lib/generators/blacklight/access_controls_generator.rb
+++ b/lib/generators/blacklight/access_controls_generator.rb
@@ -41,7 +41,7 @@ module Blacklight
   include Blacklight::AccessControls::Catalog
 
   # Apply the blacklight-access_controls
-  before_filter :enforce_show_permissions, only: :show
+  before_action :enforce_show_permissions, only: :show
 
       EOS
 


### PR DESCRIPTION
Rails 5.1 will remove `before_filter`, leaving only `before_action`