### PR TITLE
Enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.byebug_history
 .rvmrc
 Gemfile.lock
 

--- a/lib/blacklight/access_controls/catalog.rb
+++ b/lib/blacklight/access_controls/catalog.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
-# This is behavior for the catalog controller.
-
 module Blacklight
   module AccessControls
+    # This is behavior for the catalog controller.
     module Catalog
       extend ActiveSupport::Concern
 
-      # Controller "before" filter for enforcing access controls
-      # on show actions.
+      # Controller "before" filter for enforcing access controls on show actions.
       # @param [Hash] _opts (optional, not currently used)
       def enforce_show_permissions(_opts = {})
         permissions = current_ability.permissions_doc(params[:id])

--- a/lib/blacklight/access_controls/enforcement.rb
+++ b/lib/blacklight/access_controls/enforcement.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 module Blacklight
   module AccessControls
+    # Attributes and methods used to restrict access via Solr.
+    #
+    # Note: solr_access_filters_logic is an Array of Symbols.
+    # It sets defaults. Each symbol identifies a _method_ that must be in
+    # this class, taking two parameters (permission_types, ability).
+    # Can be changed in local apps or by plugins, e.g.:
+    #   CatalogController.include ModuleDefiningNewMethod
+    #   CatalogController.solr_access_filters_logic += [:new_method]
+    #   CatalogController.solr_access_filters_logic.delete(:we_dont_want)
     module Enforcement
       extend ActiveSupport::Concern
 
       included do
         extend Deprecation
-        attr_writer :current_ability
+        attr_writer :current_ability, :discovery_permissions
         deprecation_deprecate :current_ability=
 
         class_attribute :solr_access_filters_logic
+        alias_method :add_access_controls_to_solr_params, :apply_gated_discovery
 
-        # Set defaults. Each symbol identifies a _method_ that must be in
-        # this class, taking one parameter (permission_types)
-        # Can be changed in local apps or by plugins, eg:
-        # CatalogController.include ModuleDefiningNewMethod
-        # CatalogController.solr_access_filters_logic += [:new_method]
-        # CatalogController.solr_access_filters_logic.delete(:we_dont_want)
         self.solr_access_filters_logic = [:apply_group_permissions, :apply_user_permissions]
 
         # Apply appropriate access controls to all solr queries
@@ -25,72 +29,61 @@ module Blacklight
 
       delegate :current_ability, to: :scope
 
-      protected
-
-      def gated_discovery_filters(permission_types = discovery_permissions, ability = current_ability)
-        user_access_filters = []
-
-        # Grant access based on user id & group
-        solr_access_filters_logic.each do |method_name|
-          user_access_filters += send(method_name, permission_types, ability)
-        end
-        user_access_filters
-      end
-
-      #
-      # Solr query modifications
-      #
-
-      # Set solr_parameters to enforce appropriate permissions
-      # * Applies a lucene query to the solr :q parameter for gated discovery
-      # * Uses public_qt search handler if user does not have "read" permissions
-      # @param solr_parameters the current solr parameters
-      def add_access_controls_to_solr_params(solr_parameters)
-        apply_gated_discovery(solr_parameters)
-      end
-
       # Which permission levels (logical OR) will grant you the ability to discover documents in a search.
-      # Override this method if you want it to be something other than the default
+      # Override this method if you want it to be something other than the default, or hit the setter
       def discovery_permissions
         @discovery_permissions ||= %w(discover read)
       end
 
-      def discovery_permissions=(permissions)
-        @discovery_permissions = permissions
+      protected
+
+      # Grant access based on user id & group
+      # @return [Array{Array{String}}]
+      def gated_discovery_filters(permission_types = discovery_permissions, ability = current_ability)
+        solr_access_filters_logic.map { |method| send(method, permission_types, ability).reject(&:blank?) }
       end
 
-      # Controller before filter that sets up access-controlled lucene query in order to provide gated discovery behavior
-      # @param solr_parameters the current solr parameters
+      ### Solr query modifications
+
+      # Controller before_filter that sets up access-controlled lucene query to provide gated discovery behavior.
+      # Set solr_parameters to enforce appropriate permissions.
+      # @param [Hash{Object}] solr_parameters the current solr parameters, to be modified herein!
+      # @note Applies a lucene filter query to the solr :fq parameter for gated discovery.
       def apply_gated_discovery(solr_parameters)
         solr_parameters[:fq] ||= []
-        solr_parameters[:fq] << gated_discovery_filters.join(' OR ')
+        solr_parameters[:fq] << gated_discovery_filters.reject(&:blank?).join(' OR ')
         Rails.logger.debug("Solr parameters: #{solr_parameters.inspect}")
       end
 
+      # For groups
+      # @return [Array{String}] values are lucence syntax term queries suitable for :fq
+      # @example
+      #   [ "({!terms f=discover_access_group_ssim}public,faculty,africana-faculty,registered)",
+      #     "({!terms f=read_access_group_ssim}public,faculty,africana-faculty,registered)" ]
       def apply_group_permissions(permission_types, ability = current_ability)
-        # for groups
+        groups = ability.user_groups
+        return [] if groups.empty?
         permission_types.map do |type|
           field = solr_field_for(type, 'group')
-          groups = ability.user_groups
-          # The parens are required to properly OR the cases together.
-          "({!terms f=#{field}}#{groups.join(',')})"
+          "({!terms f=#{field}}#{groups.join(',')})" # parens required to properly OR the clauses together.
         end
       end
 
+      # For individual user access
+      # @return [Array{String}] values are lucence syntax term queries suitable for :fq
+      # @example ['discover_access_person_ssim:user_1@abc.com', 'read_access_person_ssim:user_1@abc.com']
       def apply_user_permissions(permission_types, ability = current_ability)
-        # for individual user access
-        user_access_filters = []
         user = ability.current_user
-        if user && user.user_key.present?
-          permission_types.each do |type|
-            user_access_filters << escape_filter(solr_field_for(type, 'user'), user.user_key)
-          end
+        return [] unless user && user.user_key.present?
+        permission_types.map do |type|
+          escape_filter(solr_field_for(type, 'user'), user.user_key)
         end
-        user_access_filters
       end
 
-      # Find the name of the solr field for this type of permission.
-      # e.g. "read_access_group_ssim" or "discover_access_person_ssim".
+      # @param [#to_s] permission_type a single value, e.g. "read" or "discover"
+      # @param [#to_s] permission_category a single value, e.g. "group" or "person"
+      # @return [String] name of the solr field for this type of permission
+      # @example return values: "read_access_group_ssim" or "discover_access_person_ssim"
       def solr_field_for(permission_type, permission_category)
         method_name = "#{permission_type}_#{permission_category}_field".to_sym
         Blacklight::AccessControls.config.send(method_name)

--- a/lib/blacklight/access_controls/enforcement.rb
+++ b/lib/blacklight/access_controls/enforcement.rb
@@ -40,7 +40,7 @@ module Blacklight
       # Grant access based on user id & group
       # @return [Array{Array{String}}]
       def gated_discovery_filters(permission_types = discovery_permissions, ability = current_ability)
-        solr_access_filters_logic.map { |method| send(method, permission_types, ability).reject(&:blank?) }
+        solr_access_filters_logic.map { |method| send(method, permission_types, ability).reject(&:blank?) }.reject(&:empty?)
       end
 
       ### Solr query modifications

--- a/lib/generators/blacklight/ability.rb
+++ b/lib/generators/blacklight/ability.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 class Ability
-  include CanCan::Ability
   include Blacklight::AccessControls::Ability
 end


### PR DESCRIPTION
Changes appear larger than they actually are, but include:
- Correct comment about solr_access_filters_logic params
- Un-protect `discovery_permissions` getter/setter
- Use attribute and alias declarations where possible
- Lots more YARD doc for all
- Delete `#except` and `#append` tests, these were testing SearchBuilder, not Enforcement.  Apparently the methods existed in Enforcement once, but were deleted.  The tests remained and still passed, so that gives you an idea of how useful they were.
- Stop testing SearchBuilder, start testing a class including the module.  That class represents our downstream consumers, not SearchBuilder.
- Additional tests for a couple basic operations and exclusion of empty clauses