### PR TITLE
Use the correct Blacklight exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,8 +8,28 @@ AllCops:
   Exclude:
     - '.internal_test_app/**/*'
 
+Bundler/DuplicatedGem:
+  Enabled: false
+
+Style/FileName:
+  Exclude:
+    - 'Gemfile'
+    - 'blacklight-access_controls.gemspec'
+    - 'lib/blacklight-access_controls.rb'
+
+Style/MixinGrouping:
+  Enabled: false # pending fix of https://github.com/bbatsov/rubocop/issues/4172
+
 Rails:
   Enabled: true
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/LineLength:
   Max: 185
+
+RSpec/MessageSpies:
+  Enabled: false
+  

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify gem dependencies in blacklight-access_controls.gemspec
 gemspec
@@ -29,9 +29,9 @@ else
 
   case ENV['RAILS_VERSION']
   when /^4.2/
+    gem 'coffee-rails', '~> 4.1.0'
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
   when /^4.[01]/
     gem 'sass-rails', '< 5.0'
   end

--- a/blacklight-access_controls.gemspec
+++ b/blacklight-access_controls.gemspec
@@ -1,32 +1,32 @@
-version = File.read(File.expand_path("../VERSION", __FILE__)).strip
+version = File.read(File.expand_path('../VERSION', __FILE__)).strip
 
 Gem::Specification.new do |gem|
-  gem.name          = "blacklight-access_controls"
+  gem.name          = 'blacklight-access_controls'
 
-  gem.description   = %q{Access controls for blacklight-based applications}
-  gem.summary       = %q{Access controls for blacklight-based applications}
-  gem.homepage      = "https://github.com/projectblacklight/blacklight-access_controls"
-  gem.email         = ["blacklight-development@googlegroups.com"]
-  gem.authors       = ["Chris Beer", "Justin Coyne", "Matt Zumwalt", "Valerie Maher"]
+  gem.description   = 'Access controls for blacklight-based applications'
+  gem.summary       = 'Access controls for blacklight-based applications'
+  gem.homepage      = 'https://github.com/projectblacklight/blacklight-access_controls'
+  gem.email         = ['blacklight-development@googlegroups.com']
+  gem.authors       = ['Chris Beer', 'Justin Coyne', 'Matt Zumwalt', 'Valerie Maher']
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
   gem.version       = version
-  gem.license       = "APACHE2"
+  gem.license       = 'APACHE2'
 
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'cancancan', '~> 1.8'
-  gem.add_dependency "blacklight", '~> 6.0'
-  gem.add_dependency "deprecation", '~> 1.0'
+  gem.add_dependency 'blacklight', '~> 6.0'
+  gem.add_dependency 'deprecation', '~> 1.0'
 
-  gem.add_development_dependency "rake", '~> 11.3'
+  gem.add_development_dependency 'rake', '~> 11.3'
   gem.add_development_dependency 'rspec', '~> 3.1'
-  gem.add_development_dependency "engine_cart", "~> 1.0"
-  gem.add_development_dependency "solr_wrapper"
-  gem.add_development_dependency "factory_girl_rails", "~> 4.0"
-  gem.add_development_dependency "database_cleaner"
+  gem.add_development_dependency 'engine_cart', '~> 1.0'
+  gem.add_development_dependency 'solr_wrapper'
+  gem.add_development_dependency 'factory_girl_rails', '~> 4.0'
+  gem.add_development_dependency 'database_cleaner'
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'rubocop-rspec'
 end

--- a/lib/blacklight-access_controls.rb
+++ b/lib/blacklight-access_controls.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails'
 require 'cancan'
 require 'blacklight'

--- a/lib/blacklight/access_controls.rb
+++ b/lib/blacklight/access_controls.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Blacklight
   module AccessControls
     extend ActiveSupport::Autoload

--- a/lib/blacklight/access_controls/ability.rb
+++ b/lib/blacklight/access_controls/ability.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'cancan'
 
 module Blacklight
@@ -14,7 +15,7 @@ module Blacklight
         # permission methods to ability_logic, like so:
         # self.ability_logic += [:setup_my_permissions]
         class_attribute :ability_logic
-        self.ability_logic = [:discover_permissions, :read_permissions, :download_permissions]
+        self.ability_logic = %i(discover_permissions read_permissions download_permissions)
       end
 
       def initialize(user, options = {})

--- a/lib/blacklight/access_controls/catalog.rb
+++ b/lib/blacklight/access_controls/catalog.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Blacklight
   module AccessControls
     # This is behavior for the catalog controller.

--- a/lib/blacklight/access_controls/config.rb
+++ b/lib/blacklight/access_controls/config.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Blacklight
   module AccessControls
     class Config

--- a/lib/blacklight/access_controls/enforcement.rb
+++ b/lib/blacklight/access_controls/enforcement.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Blacklight
   module AccessControls
     # Attributes and methods used to restrict access via Solr.
@@ -21,7 +22,7 @@ module Blacklight
         class_attribute :solr_access_filters_logic
         alias_method :add_access_controls_to_solr_params, :apply_gated_discovery
 
-        self.solr_access_filters_logic = [:apply_group_permissions, :apply_user_permissions]
+        self.solr_access_filters_logic = %i(apply_group_permissions apply_user_permissions)
 
         # Apply appropriate access controls to all solr queries
         self.default_processor_chain += [:add_access_controls_to_solr_params] if respond_to?(:default_processor_chain)

--- a/lib/blacklight/access_controls/permissions_cache.rb
+++ b/lib/blacklight/access_controls/permissions_cache.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Blacklight::AccessControls::PermissionsCache
   def initialize
     clear

--- a/lib/blacklight/access_controls/permissions_query.rb
+++ b/lib/blacklight/access_controls/permissions_query.rb
@@ -24,12 +24,12 @@ module Blacklight::AccessControls
     # @param [String] id of the documetn to retrieve
     # @param [Hash] extra_controller_params (optional)
     def get_permissions_solr_response_for_doc_id(id = nil, extra_controller_params = {})
-      raise Blacklight::Exceptions::InvalidSolrID, 'The application is trying to retrieve permissions without specifying an asset id' if id.nil?
+      raise Blacklight::Exceptions::RecordNotFound, 'The application is trying to retrieve permissions without specifying an asset id' if id.nil?
       solr_opts = permissions_solr_doc_params(id).merge(extra_controller_params)
       response = Blacklight.default_index.connection.get('select', params: solr_opts)
       solr_response = Blacklight::Solr::Response.new(response, solr_opts, document_model: permissions_document_class)
 
-      raise Blacklight::Exceptions::InvalidSolrID, "The solr permissions search handler didn't return anything for id \"#{id}\"" if solr_response.docs.empty?
+      raise Blacklight::Exceptions::RecordNotFound, "The solr permissions search handler didn't return anything for id \"#{id}\"" if solr_response.docs.empty?
       solr_response.docs.first
     end
 

--- a/lib/blacklight/access_controls/permissions_query.rb
+++ b/lib/blacklight/access_controls/permissions_query.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Blacklight::AccessControls
   module PermissionsQuery
     extend ActiveSupport::Concern

--- a/lib/blacklight/access_controls/user.rb
+++ b/lib/blacklight/access_controls/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Injects behaviors into User model so that it will work with
 # Blacklight Access Controls.  By default, this module assumes
 # you are using the User model created by Blacklight, which uses

--- a/lib/generators/blacklight/ability.rb
+++ b/lib/generators/blacklight/ability.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Ability
   include Blacklight::AccessControls::Ability
 end

--- a/lib/generators/blacklight/access_controls_generator.rb
+++ b/lib/generators/blacklight/access_controls_generator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Blacklight
   class AccessControlsGenerator < Rails::Generators::Base
     desc "This generator makes the following changes to your application:

--- a/lib/generators/blacklight/blacklight_access_controls.rb
+++ b/lib/generators/blacklight/blacklight_access_controls.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Blacklight::AccessControls.configure do |config|
   # This specifies the solr field names of permissions-related fields.
   # The default fields used are shown below, if you index your permissions to other fields update the configuration below.

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "user_#{n}@example.com" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'engine_cart'

--- a/spec/support/solr_support.rb
+++ b/spec/support/solr_support.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module SolrSupport
   def create_solr_doc(hash)
     doc = SolrDocument.new(hash)

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails/generators'
 
 class TestAppGenerator < Rails::Generators::Base

--- a/spec/unit/ability_spec.rb
+++ b/spec/unit/ability_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'cancan/matchers'
 
 describe Ability do
@@ -21,35 +22,37 @@ describe Ability do
 
     context 'Then a not-signed-in user' do
       let(:user) { nil }
+
       subject { ability }
 
-      it { should     be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.to     be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then a registered user' do
       let(:user) { create(:user) }
+
       subject { ability }
 
-      it { should     be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.to     be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'With an ID instead of a SolrDocument' do
-      let(:user) { create(:user) }
       subject { ability }
 
+      let(:user) { create(:user) }
       let(:asset) {
         create_solr_doc(id: 'public_discovery',
                         discover_access_group_ssim: ['public'])
       }
 
       # It should still work, even if we just pass in an ID
-      it { should     be_able_to(:discover, asset.id) }
-      it { should_not be_able_to(:read, asset.id) }
-      it { should_not be_able_to(:download, asset.id) }
+      it { is_expected.to     be_able_to(:discover, asset.id) }
+      it { is_expected.not_to be_able_to(:read, asset.id) }
+      it { is_expected.not_to be_able_to(:download, asset.id) }
     end
   end
 
@@ -59,35 +62,37 @@ describe Ability do
 
     context 'Then a not-signed-in user' do
       let(:user) { nil }
+
       subject { ability }
 
-      it { should     be_able_to(:discover, asset) }
-      it { should     be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.to     be_able_to(:discover, asset) }
+      it { is_expected.to     be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then a registered user' do
       let(:user) { create(:user) }
+
       subject { ability }
 
-      it { should     be_able_to(:discover, asset) }
-      it { should     be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.to     be_able_to(:discover, asset) }
+      it { is_expected.to     be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'With an ID instead of a SolrDocument' do
-      let(:user) { create(:user) }
       subject { ability }
 
+      let(:user) { create(:user) }
       let(:asset) {
         create_solr_doc(id: 'public_read',
                         read_access_group_ssim: ['public'])
       }
 
       # It should still work, even if we just pass in an ID
-      it { should     be_able_to(:discover, asset.id) }
-      it { should     be_able_to(:read, asset.id) }
-      it { should_not be_able_to(:download, asset.id) }
+      it { is_expected.to     be_able_to(:discover, asset.id) }
+      it { is_expected.to     be_able_to(:read, asset.id) }
+      it { is_expected.not_to be_able_to(:download, asset.id) }
     end
   end
 
@@ -98,35 +103,37 @@ describe Ability do
 
     context 'Then a not-signed-in user' do
       let(:user) { nil }
+
       subject { ability }
 
-      it { should be_able_to(:discover, asset) }
-      it { should be_able_to(:read, asset) }
-      it { should be_able_to(:download, asset) }
+      it { is_expected.to be_able_to(:discover, asset) }
+      it { is_expected.to be_able_to(:read, asset) }
+      it { is_expected.to be_able_to(:download, asset) }
     end
 
     context 'Then a registered user' do
-      let(:user) { create(:user) }
       subject { ability }
 
-      it { should be_able_to(:discover, asset) }
-      it { should be_able_to(:read, asset) }
-      it { should be_able_to(:download, asset) }
+      let(:user) { create(:user) }
+
+      it { is_expected.to be_able_to(:discover, asset) }
+      it { is_expected.to be_able_to(:read, asset) }
+      it { is_expected.to be_able_to(:download, asset) }
     end
 
     context 'With an ID instead of a record' do
-      let(:user) { create(:user) }
       subject { ability }
 
+      let(:user) { create(:user) }
       let(:asset) {
         create_solr_doc(id: id,
                         download_access_group_ssim: ['public'])
       }
 
       # It should still work, even if we just pass in an ID
-      it { should be_able_to(:discover, asset.id) }
-      it { should be_able_to(:read, asset.id) }
-      it { should be_able_to(:download, asset.id) }
+      it { is_expected.to be_able_to(:discover, asset.id) }
+      it { is_expected.to be_able_to(:read, asset.id) }
+      it { is_expected.to be_able_to(:download, asset.id) }
     end
   end
 
@@ -136,29 +143,32 @@ describe Ability do
 
     context 'Then a not-signed-in user' do
       let(:user) { nil }
+
       subject { ability }
 
-      it { should_not be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.not_to be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then a different registered user' do
       let(:user) { create(:user) }
+
       subject { ability }
 
-      it { should_not be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.not_to be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then that user' do
       let(:user) { user_with_access }
+
       subject { ability }
 
-      it { should     be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.to     be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
   end
 
@@ -168,29 +178,32 @@ describe Ability do
 
     context 'Then a not-signed-in user' do
       let(:user) { nil }
+
       subject { ability }
 
-      it { should_not be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.not_to be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then a different registered user' do
       let(:user) { create(:user) }
+
       subject { ability }
 
-      it { should_not be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.not_to be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then that user' do
       let(:user) { user_with_access }
+
       subject { ability }
 
-      it { should     be_able_to(:discover, asset) }
-      it { should     be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.to     be_able_to(:discover, asset) }
+      it { is_expected.to     be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
   end
 
@@ -200,39 +213,44 @@ describe Ability do
 
     context 'Then a not-signed-in user' do
       let(:user) { nil }
+
       subject { ability }
 
-      it { should_not be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.not_to be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then a different registered user' do
       let(:user) { create(:user) }
+
       subject { ability }
 
-      it { should_not be_able_to(:discover, asset) }
-      it { should_not be_able_to(:read, asset) }
-      it { should_not be_able_to(:download, asset) }
+      it { is_expected.not_to be_able_to(:discover, asset) }
+      it { is_expected.not_to be_able_to(:read, asset) }
+      it { is_expected.not_to be_able_to(:download, asset) }
     end
 
     context 'Then that user' do
       let(:user) { user_with_access }
+
       subject { ability }
 
-      it { should be_able_to(:discover, asset) }
-      it { should be_able_to(:read, asset) }
-      it { should be_able_to(:download, asset) }
+      it { is_expected.to be_able_to(:discover, asset) }
+      it { is_expected.to be_able_to(:read, asset) }
+      it { is_expected.to be_able_to(:download, asset) }
     end
   end
 
   describe '.user_class' do
     subject { Blacklight::AccessControls::Ability.user_class }
+
     it { is_expected.to eq User }
   end
 
   describe '#guest_user' do
     let(:user) { nil }
+
     subject { ability.guest_user }
 
     it 'is a new user' do
@@ -246,22 +264,26 @@ describe Ability do
 
     context 'an unregistered user' do
       let(:user) { build(:user) }
+
       it { is_expected.to contain_exactly('public') }
     end
 
     context 'a registered user' do
       let(:user) { create(:user) }
+
       it { is_expected.to contain_exactly('registered', 'public') }
     end
 
     context 'a user with groups' do
       let(:user) { double(groups: %w(group1 group2), new_record?: false) }
+
       it { is_expected.to include('group1', 'group2') }
     end
   end
 
   describe 'with a custom method' do
     let(:user) { create(:user) }
+
     subject { MyAbility.new(user) }
 
     before do
@@ -280,6 +302,6 @@ describe Ability do
     end
 
     # Make sure it called the custom method
-    it { should be_able_to(:accept, SolrDocument) }
+    it { is_expected.to be_able_to(:accept, SolrDocument) }
   end
 end

--- a/spec/unit/catalog_spec.rb
+++ b/spec/unit/catalog_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
+
 describe Blacklight::AccessControls::Catalog do
   let(:controller) { CatalogController.new }
 
   describe '#enforce_show_permissions' do
     subject { controller.send(:enforce_show_permissions) }
+
     let(:params) { { id: doc.id } }
 
     before do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Blacklight::AccessControls::Config do
   let(:config) { described_class.new }
 

--- a/spec/unit/enforcement_spec.rb
+++ b/spec/unit/enforcement_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class MyController # < ApplicationController
   include Blacklight::AccessControls::Enforcement
 end
@@ -11,6 +12,7 @@ describe Blacklight::AccessControls::Enforcement do
   end
   let(:user) { User.new }
   let(:ability) { Ability.new(user) }
+
   subject { controller }
 
   describe '#discovery_permissions' do
@@ -33,10 +35,10 @@ describe Blacklight::AccessControls::Enforcement do
       solr_parameters[:fq].first
     end
 
-    # rubocop:disable RSpec/MessageExpectation
     describe 'logger' do
       # Expectation will be triggered by Ability class (that calls Rails.logger.debug earlier). So we double Ability to avoid false positive.
       let(:ability) { instance_double(Ability, user_groups: [], current_user: user) }
+
       it 'is called with debug' do
         expect(Rails.logger).to receive(:debug).with(/^Solr parameters/)
         controller.send(:apply_gated_discovery, {})
@@ -114,6 +116,7 @@ describe Blacklight::AccessControls::Enforcement do
 
     describe 'when the user is a guest user (user key empty string)' do
       let(:user) { User.new(email: '') }
+
       it 'does not create filters' do
         expect(subject.send(:apply_user_permissions, %w(discover read))).to eq []
       end


### PR DESCRIPTION
InvalidSolrID was switched to RecordNotFound in Blacklight 5.10, but
blacklight-access-controls require Blacklight 6.

https://github.com/projectblacklight/blacklight/commit/32832e77cddd9e4d91438cde0d548ea807a65a17